### PR TITLE
Add Mobile Browser Testing to Playwright

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -51,14 +51,18 @@ export default defineConfig({
     },
 
     /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+    {
+      name: 'Mobile Firefox',
+      use: { ...devices['Galaxy S9'] },
+    },
 
     /* Test against branded browsers. */
     // {


### PR DESCRIPTION
Enhanced the Playwright test suite by adding support for mobile browsers, including Mobile Chrome, Mobile Safari, and Mobile Firefox. Updated the `playwright.config.js` file to include these configurations.

closes #KAN-14