### PR TITLE
Add new testing method for Playwright

### DIFF
--- a/tests/new-testing-method.spec.js
+++ b/tests/new-testing-method.spec.js
@@ -1,0 +1,9 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+
+test('new testing method', async ({ page }) => {
+  await page.goto('https://playwright.dev/');
+
+  // Perform a new test action.
+  await expect(page.getByRole('link', { name: 'Docs' })).toBeVisible();
+});


### PR DESCRIPTION
Implemented a new testing method as per the requirements in Jira ticket KAN-15. The new test ensures visibility of the 'Docs' link on the Playwright homepage.

closes #KAN-15